### PR TITLE
Feature/return indices of cases

### DIFF
--- a/src/reporting.jl
+++ b/src/reporting.jl
@@ -25,6 +25,7 @@ result_show(::Test.Error, ::Verbosity{1}) = "E"
 result_show(::Test.Error, ::Verbosity{2}) = "ERROR"
 result_show(::FailExplanation, ::Verbosity{1}) = "F"
 result_show(::FailExplanation, ::Verbosity{2}) = "FAIL"
+result_show(::JuteTestSet, ::Verbosity) = ""
 
 
 function Base.show(io::IO, fe::FailExplanation)

--- a/src/reporting.jl
+++ b/src/reporting.jl
@@ -25,7 +25,7 @@ result_show(::Test.Error, ::Verbosity{1}) = "E"
 result_show(::Test.Error, ::Verbosity{2}) = "ERROR"
 result_show(::FailExplanation, ::Verbosity{1}) = "F"
 result_show(::FailExplanation, ::Verbosity{2}) = "FAIL"
-result_show(::JuteTestSet, ::Verbosity) = nothing
+result_show(::JuteTestSet, ::Verbosity) = ""
 
 
 function Base.show(io::IO, fe::FailExplanation)
@@ -150,7 +150,7 @@ function progress_finish_testcase!(
 
         for result in outcome.results
             result_str = result_show(result, Verbosity{verbosity}())
-            if !isnothing(result_str)
+            if result_str != ""
                 printstyled(
                     " [$result_str]",
                     color=result_color(color_scheme, result, Verbosity{verbosity}()))

--- a/src/reporting.jl
+++ b/src/reporting.jl
@@ -25,7 +25,7 @@ result_show(::Test.Error, ::Verbosity{1}) = "E"
 result_show(::Test.Error, ::Verbosity{2}) = "ERROR"
 result_show(::FailExplanation, ::Verbosity{1}) = "F"
 result_show(::FailExplanation, ::Verbosity{2}) = "FAIL"
-result_show(::JuteTestSet, ::Verbosity) = ""
+result_show(::JuteTestSet, ::Verbosity) = nothing
 
 
 function Base.show(io::IO, fe::FailExplanation)
@@ -150,9 +150,11 @@ function progress_finish_testcase!(
 
         for result in outcome.results
             result_str = result_show(result, Verbosity{verbosity}())
-            printstyled(
-                " [$result_str]",
-                color=result_color(color_scheme, result, Verbosity{verbosity}()))
+            if !isnothing(result_str)
+                printstyled(
+                    " [$result_str]",
+                    color=result_color(color_scheme, result, Verbosity{verbosity}()))
+            end
         end
         println()
     end

--- a/test/run_testcase.test.jl
+++ b/test/run_testcase.test.jl
@@ -224,4 +224,14 @@ end
 end
 
 
+@testcase "A parent test set can see child Jute test cases" begin
+    ts = Jute.Test.@testset "Aggregator" begin
+        outcome = get_outcome() do
+            @test 1 == 1
+        end
+    end
+    @test length(ts.results) == 1
+    @test ts.results[1].description == "tc"
+end
+
 end


### PR DESCRIPTION
Hi! This PR lets the TestReports.jl package create an XML test report from a Jute.jl run. It does this by changing the JuteTestSet type so that it passes test results to any AbstractTestSet that contains this JuteTestSet. The results are passed in the `finish()` method of the JuteTestSet, so you will see that there is now a call to `record()` of the parent test set. One side-effect of recording with the parent is that the JuteTestSet's `result` array is now of a different type. It was of type `Array{TestResult,1}` and is now of type `Vector`, which is the same as `Array{T,1} where T`. This result type matches that of the example in Julia's `DefaultTestSet`. It has to be that way so that it can store not only TestResult types but also TestSet types, as results move up the hierarchy. One other change is that the reporting will try to show the results of a TestSet. That's not necessary here, so I set that to print `""`.

OK, if there is anything at all you would like different about this, please tell me, and I'll rectify it. I tried to match overall style, but I may have missed things. If it's easier for you to change it, then I'll give you access to the branch. Any way you'd like.

I think the next step, after this PR is merged, if it's merged, is to try to make Jute.jl work with TestReports under Github Actions. If that works, then Jute will be more of a drop-in replacement for Test. The changes would be 1) to change runtests.jl so that it doesn't `exit()` and 2) update the documentation with instructions.